### PR TITLE
Request to add aseprite image loader package to graphics libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you have a great article or tutorial, please submit it through issues.
 
 <a href="#contents"><img src="https://user-images.githubusercontent.com/19890545/150034365-6561ab71-5cb4-466f-996c-ae4204ef7c12.png" alt="back" title="back" width="16px"/></a> *Useful libraries for graphics*
 
+* [aseprite](https://github.com/askeladdk/aseprite) - An image loader for Aseprite files, supports animation tags, layers and more.
 * [tetra3d](https://github.com/SolarLune/Tetra3d) - A 3D software renderer written in Go by means of Ebitengine, primarily for video games.
 * [etxt](https://github.com/tinne26/etxt) - A library for font management and text rendering in Ebitengine.
 * [canvas](https://github.com/eihigh/canvas) - Cairo in Go for Ebitengine.


### PR DESCRIPTION
Hi,

I wrote a package for loading Aseprite files. It's pretty useful because you can use it to load Aseprite sprites directly without having to export to another format first. Layers are flattened, blending modes are applied, and frames are arranged on a single texture atlas. It also preserves the metadata for frames, tags and a few other things.

I would appreciate it if you add it to the list. Thanks!