### PR TITLE
#43 Remove screenpos link

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ If you have a great article or tutorial, please submit it through issues.
 
 * [sketchy](https://github.com/aldernero/sketchy) - A framework for creating generative art in Go.
 * [darktile](https://github.com/liamg/darktile) - A GPU rendered terminal emulator designed for tiling window managers.
-* [screenpos](https://github.com/barjoio/screenpos) - A simple way to get a position on your screen using your keyboard and the visual aid of a grid.
 * [wasmserve](https://github.com/hajimehoshi/wasmserve) - An HTTP server for Wasm testing like gopherjs serve.
 * [ebiten-bunny-mark](https://github.com/sedyh/ebiten-bunny-mark) - An implementation of the popular graphics benchmark written on Ebitengine.
 * [neko](https://github.com/crgimenes/neko) - Neko is a cross-platform open-source animated cursor-chasing cat.

--- a/README.md
+++ b/README.md
@@ -203,3 +203,4 @@ If you have a great article or tutorial, please submit it through issues.
 * [neko](https://github.com/crgimenes/neko) - Neko is a cross-platform open-source animated cursor-chasing cat.
 * [kagei](https://github.com/MatusOllah/kagei) - A CLI tool for testing Kage shaders.
 * [kageviewer](https://github.com/TLINDEN/kageviewer) - A CLI tool to run, view and test Kage shaders.
+


### PR DESCRIPTION
As per ticket (#43 ) the link doesn't link to anything useful anymore.