### PR TITLE
Added elgopher/pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you see a package or project here that is no longer maintained or is not a go
 * [routine](https://github.com/SolarLune/routine) - A package for running routines.
 * [mipix](https://github.com/tinne26/mipix) - A pixel art aware layout and camera managment.
 * [egriden](https://github.com/greenthepear/egriden) - Framework for creating grid-based games and more.
+* [pi](https://github.com/elgopher/pi) - Game engine for creating retro games for modern computers. Inspired by Pico-8 and powered by Ebitengine.
 
 ### GUI
 


### PR DESCRIPTION
I've added Pi - a game engine for creating retro games for modern computers. The project is Inspired by Pico-8 and implemented in Ebitengine.

Project repo: https://github.com/elgopher/pi

I am not sure which category should I choose. Pi limits what developer can do - so i put it in the frameworks list.
