### PR TITLE
add kutta (2D wind tunnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you see a package or project here that is no longer maintained or is not a go
 * [kageland](https://www.kageland.com/) - A website to create, find and share Kage shaders - inspired by Shadertoy.
 * [luluka](https://github.com/Tsukumogami-Software/luluka) - A CLI tool to preview Kage shaders, with support for PNG textures and uniform values defined in YAML.
 * [turtle](https://github.com/gary23b/turtle) - Turtle graphics. Teach Golang programming with instant visual feedback.
+* [kutta](https://github.com/crgimenes/kutta) - A 2D wind tunnel: qualitative airfoil flow with smoke streaklines, a scene editor and animated control surfaces.
 
 #### Articles
 


### PR DESCRIPTION
Adds [kutta](https://github.com/crgimenes/kutta) to Applications: a 2D wind tunnel written in pure Go with Ebitengine. Qualitative airfoil flow with smoke streaklines, a scene editor with keyframed control surfaces, and a live lift curve. Same code runs on desktop and in the browser via wasm ([play here](https://crgimenes.itch.io/kutta)).